### PR TITLE
Add replicateSubscriptionState in consumerConfig

### DIFF
--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/ConsumerConfig.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/ConsumerConfig.scala
@@ -27,5 +27,6 @@ case class ConsumerConfig(subscriptionName: Subscription,
                           ackTimeoutTickTime: Option[FiniteDuration] = None,
                           acknowledgmentGroupTime: Option[FiniteDuration] = None,
                           additionalProperties: Map[String, AnyRef] = Map.empty,
-                          deadLetterPolicy: Option[DeadLetterPolicy] = None)
+                          deadLetterPolicy: Option[DeadLetterPolicy] = None,
+                          replicateSubscriptionState:Boolean=false)
 

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/PulsarClient.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/PulsarClient.scala
@@ -170,7 +170,7 @@ class DefaultPulsarClient(client: org.apache.pulsar.client.api.PulsarClient) ext
 
   private def consumerBuilder[T](config: ConsumerConfig, interceptors: List[ConsumerInterceptor[T]] = Nil)(implicit schema: Schema[T]): ConsumerBuilder[T] = {
     logger.info(s"Creating consumer with config $config")
-    val builder = client.newConsumer(schema)
+    val builder = client.newConsumer(schema).replicateSubscriptionState(config.replicateSubscriptionState)
     config.consumerEventListener.foreach(builder.consumerEventListener)
     config.consumerName.foreach(builder.consumerName)
     config.cryptoFailureAction.foreach(builder.cryptoFailureAction)


### PR DESCRIPTION
 Add replicateSubscriptionState in ConsumerConfig
 Update consumerBuilder to set the flag on newConsumer
 from consumerConfig.
 This is needed in georeplication in order to maintain the state
 of consumer