### PR TITLE
Use bytes schema for Jackson

### DIFF
--- a/pulsar4s-jackson/src/main/scala/com/sksamuel/pulsar4s/jackson/package.scala
+++ b/pulsar4s-jackson/src/main/scala/com/sksamuel/pulsar4s/jackson/package.scala
@@ -12,8 +12,8 @@ package object jackson {
     override def getSchemaInfo: SchemaInfo =
       SchemaInfoImpl.builder()
         .name(manifest[T].runtimeClass.getCanonicalName)
-        .`type`(SchemaType.JSON)
-        .schema("""{"type":"any"}""".getBytes("UTF-8"))
+        .`type`(SchemaType.BYTES)
+        .schema(Array.empty[Byte])
         .build()
   }
 }


### PR DESCRIPTION
Somehow I missed this in https://github.com/CleverCloud/pulsar4s/pull/298

Perhaps there are other improvements we can do here that I'm missing, but this is just to bring it to parity with the other schemas.