### PR TITLE
Add `seek` and `seekAsync` with timestamp to Consumer

### DIFF
--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/AsyncHandler.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/AsyncHandler.scala
@@ -31,6 +31,7 @@ trait AsyncHandler[F[_]] {
   def flush(producer: api.Producer[_]): F[Unit]
 
   def seekAsync(consumer: api.Consumer[_], messageId: MessageId): F[Unit]
+  def seekAsync(consumer: api.Consumer[_], timestamp: Long): F[Unit]
 
   def seekAsync(reader: api.Reader[_], messageId: MessageId): F[Unit]
   def seekAsync(reader: api.Reader[_], timestamp: Long): F[Unit]

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Consumer.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Consumer.scala
@@ -60,9 +60,12 @@ trait Consumer[T] extends Closeable with TransactionalConsumerOps[T] {
   def redeliverUnacknowledgedMessages(): Unit
 
   def seek(messageId: MessageId): Unit
+  def seek(timestamp: Long): Unit
+
   def seekEarliest(): Unit = seek(MessageId.earliest)
   def seekLatest(): Unit = seek(MessageId.latest)
   def seekAsync[F[_] : AsyncHandler](messageId: MessageId): F[Unit]
+  def seekAsync[F[_] : AsyncHandler](timestamp: Long): F[Unit]
 
   def getLastMessageId(): MessageId
 
@@ -137,9 +140,14 @@ class DefaultConsumer[T](consumer: JConsumer[T]) extends Consumer[T] with Loggin
 
   override def seek(messageId: MessageId): Unit = consumer.seek(messageId)
 
+  override def seek(timestamp: Long): Unit = consumer.seek(timestamp)
+
   override def seekAsync[F[_] : AsyncHandler](messageId: MessageId): F[Unit] =
     implicitly[AsyncHandler[F]].seekAsync(consumer, messageId)
-  
+
+  override def seekAsync[F[_] : AsyncHandler](timestamp: Long): F[Unit] =
+    implicitly[AsyncHandler[F]].seekAsync(consumer, timestamp)
+
   override def getLastMessageId(): MessageId = consumer.getLastMessageId()
 
   override def getLastMessageIdAsync[F[_] : AsyncHandler]: F[MessageId] = implicitly[AsyncHandler[F]].getLastMessageId(consumer)

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Consumer.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Consumer.scala
@@ -5,6 +5,7 @@ import org.apache.pulsar.client.api.ConsumerStats
 import org.apache.pulsar.client.api.transaction.Transaction
 
 import java.io.Closeable
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
@@ -61,11 +62,16 @@ trait Consumer[T] extends Closeable with TransactionalConsumerOps[T] {
 
   def seek(messageId: MessageId): Unit
   def seek(timestamp: Long): Unit
+  def seek(timestamp: Instant): Unit =
+    seek(timestamp.toEpochMilli)
 
   def seekEarliest(): Unit = seek(MessageId.earliest)
   def seekLatest(): Unit = seek(MessageId.latest)
+
   def seekAsync[F[_] : AsyncHandler](messageId: MessageId): F[Unit]
   def seekAsync[F[_] : AsyncHandler](timestamp: Long): F[Unit]
+  def seekAsync[F[_] : AsyncHandler](timestamp: Instant): F[Unit] =
+    seekAsync[F](timestamp.toEpochMilli)
 
   def getLastMessageId(): MessageId
 

--- a/pulsar4s-monix/src/main/scala/com/sksamuel/pulsar4s/monixs/MonixAsyncHandler.scala
+++ b/pulsar4s-monix/src/main/scala/com/sksamuel/pulsar4s/monixs/MonixAsyncHandler.scala
@@ -57,14 +57,18 @@ class MonixAsyncHandler extends AsyncHandler[Task] {
   def unsubscribeAsync(consumer: api.Consumer[_]): Task[Unit] = consumer.unsubscribeAsync()
 
   override def close(producer: api.Producer[_]): Task[Unit] = producer.closeAsync()
+
   override def close(consumer: api.Consumer[_]): Task[Unit] = consumer.closeAsync()
 
   override def seekAsync(consumer: api.Consumer[_], messageId: MessageId): Task[Unit] =
     consumer.seekAsync(messageId)
-  
+
+  override def seekAsync(consumer: api.Consumer[_], timestamp: Long): Task[Unit] =
+    consumer.seekAsync(timestamp)
+
   override def seekAsync(reader: api.Reader[_], messageId: MessageId): Task[Unit] =
     reader.seekAsync(messageId)
-  
+
   override def seekAsync(reader: api.Reader[_], timestamp: Long): Task[Unit] =
     reader.seekAsync(timestamp)
 
@@ -86,13 +90,17 @@ class MonixAsyncHandler extends AsyncHandler[Task] {
   override def acknowledgeCumulativeAsync[T](consumer: api.Consumer[T], messageId: MessageId): Task[Unit] =
     consumer.acknowledgeCumulativeAsync(messageId)
 
-  override def acknowledgeCumulativeAsync[T](consumer: api.Consumer[T], messageId: MessageId, txn: Transaction): Task[Unit] =
+  override def acknowledgeCumulativeAsync[T](consumer: api.Consumer[T], messageId: MessageId,
+                                             txn: Transaction): Task[Unit] =
     consumer.acknowledgeCumulativeAsync(messageId, txn)
 
   override def negativeAcknowledgeAsync[T](consumer: Consumer[T], messageId: MessageId): Task[Unit] =
-    Task { consumer.negativeAcknowledge(messageId) }
+    Task {
+      consumer.negativeAcknowledge(messageId)
+    }
 
   override def close(reader: Reader[_]): Task[Unit] = reader.closeAsync()
+
   override def close(client: PulsarClient): Task[Unit] = client.closeAsync()
 
   override def flush(producer: api.Producer[_]): Task[Unit] = producer.flushAsync()
@@ -107,9 +115,9 @@ class MonixAsyncHandler extends AsyncHandler[Task] {
     Task.deferFuture(builder.sendAsync()).map(MessageId.fromJava)
 
   override def withTransaction[E, A](
-    builder: api.transaction.TransactionBuilder,
-    action: TransactionContext => Task[Either[E, A]]
-  ): Task[Either[E, A]] = {
+                                      builder: api.transaction.TransactionBuilder,
+                                      action: TransactionContext => Task[Either[E, A]]
+                                    ): Task[Either[E, A]] = {
     startTransaction(builder).bracketCase { txn =>
       action(txn).flatMap { result =>
         (if (result.isRight) txn.commit(this) else txn.abort(this)).map(_ => result)
@@ -119,8 +127,10 @@ class MonixAsyncHandler extends AsyncHandler[Task] {
 
   override def startTransaction(builder: api.transaction.TransactionBuilder): Task[TransactionContext] =
     Task.deferFuture(builder.build()).map(TransactionContext(_))
+
   override def commitTransaction(txn: Transaction): Task[Unit] =
     Task.deferFuture(txn.commit()).map(_ => ())
+
   override def abortTransaction(txn: Transaction): Task[Unit] =
     Task.deferFuture(txn.abort()).map(_ => ())
 }


### PR DESCRIPTION
In the Java implementation of the Consumer, there is two methods `seek` and `seekAsync` defined as
```java
    void seek(long timestamp) throws PulsarClientException;

    CompletableFuture<Void> seekAsync(long timestamp);
```

This PR aims to add these methods to the Scala implementation.

Therefore this PR suggests two main changes : 
- Adding the methods to the Consumer interface and it's implementation.
- Updating the AsyncHandler to manage the `seekAsync`.