### PR TITLE
Add Pulsar reconsumeLater API

### DIFF
--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/AsyncHandler.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/AsyncHandler.scala
@@ -4,6 +4,7 @@ import org.apache.pulsar.client.api
 import org.apache.pulsar.client.api.TypedMessageBuilder
 import org.apache.pulsar.client.api.transaction.Transaction
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -47,6 +48,7 @@ trait AsyncHandler[F[_]] {
   def acknowledgeCumulativeAsync[T](consumer: api.Consumer[T], messageId: MessageId): F[Unit]
   def acknowledgeCumulativeAsync[T](consumer: api.Consumer[T], messageId: MessageId, txn: Transaction): F[Unit]
   def negativeAcknowledgeAsync[T](consumer: api.Consumer[T], messageId: MessageId): F[Unit]
+  def reconsumeLaterAsync[T](consumer: api.Consumer[T], message: ConsumerMessage[T], delayTime: Long, unit: TimeUnit): F[Unit]
 
   def withTransaction[E, A](
     builder: api.transaction.TransactionBuilder,

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/ConsumerConfig.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/ConsumerConfig.scala
@@ -31,5 +31,6 @@ case class ConsumerConfig(subscriptionName: Subscription,
                           additionalProperties: Map[String, AnyRef] = Map.empty,
                           deadLetterPolicy: Option[DeadLetterPolicy] = None,
                           replicateSubscriptionState: Boolean = false,
-                          batchReceivePolicy: Option[BatchReceivePolicy] = None)
+                          batchReceivePolicy: Option[BatchReceivePolicy] = None,
+                          enableRetry: Option[Boolean] = None)
 

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/ConsumerMessage.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/ConsumerMessage.scala
@@ -84,7 +84,8 @@ object ConsumerMessage {
       Topic(message.getTopicName),
       message.getSchemaVersion,
       message.getRedeliveryCount,
-      Option(message.getReplicatedFrom)
+      Option(message.getReplicatedFrom),
+      () => message
     )
   }
 
@@ -123,7 +124,8 @@ case class ConsumerMessageWithValueTry[T](key: Option[String],
                                           topic: Topic,
                                           schemaVersion: Array[Byte],
                                           redeliveryCount: Int,
-                                          replicatedFrom: Option[String]) extends ConsumerMessage[T] {
+                                          replicatedFrom: Option[String],
+                                          getBaseMessage: () => JMessage[T]) extends ConsumerMessage[T] {
   def value: T = valueTry.get
 }
 

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/PulsarClient.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/PulsarClient.scala
@@ -290,6 +290,7 @@ class DefaultPulsarClient(client: org.apache.pulsar.client.api.PulsarClient) ext
     config.deadLetterPolicy.foreach(builder.deadLetterPolicy)
     config.batchReceivePolicy.foreach(builder.batchReceivePolicy)
     config.acknowledgmentGroupTime.foreach { gt => builder.acknowledgmentGroupTime(gt._1, gt._2) }
+    config.enableRetry.foreach(builder.enableRetry)
     if (config.topics.nonEmpty)
       builder.topics(config.topics.map(_.name).asJava)
     builder.subscriptionName(config.subscriptionName.name)

--- a/pulsar4s-core/src/test/scala/com/sksamuel/pulsar4s/ConsumerMessageTest.scala
+++ b/pulsar4s-core/src/test/scala/com/sksamuel/pulsar4s/ConsumerMessageTest.scala
@@ -1,6 +1,10 @@
 package com.sksamuel.pulsar4s
 
+import com.sksamuel.pulsar4s.conversions.collections._
 import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.client.impl.MessageImpl
+import org.apache.pulsar.common.api.proto.MessageMetadata
+import org.apache.pulsar.shade.io.netty.buffer.Unpooled
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -10,6 +14,8 @@ import scala.util.Try
 class ConsumerMessageTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
   test("ConsumerMessage.toJava should set metadata") {
+
+
     val message = ConsumerMessageWithValueTry(
       key = None,
       valueTry = Try("foo"),
@@ -23,7 +29,15 @@ class ConsumerMessageTest extends AnyFunSuite with Matchers with BeforeAndAfterA
       topic = Topic("t"),
       schemaVersion = Array.emptyByteArray,
       redeliveryCount = 2,
-      replicatedFrom = Some("reppy")
+      replicatedFrom = Some("reppy"),
+      () => new MessageImpl[String](
+        "test",
+        MessageId.latest.toString,
+        Map.empty[String, String].asJava,
+        Unpooled.wrappedBuffer("foo".getBytes),
+        Schema.STRING,
+        new MessageMetadata()
+      )
     )
     val java = ConsumerMessage.toJava(message, Schema.STRING)
     java.getPublishTime shouldBe 222


### PR DESCRIPTION
Pulsar has a retry letter topic feature that allows messages to be pushed to a dedicated topic while waiting to be resent to the consumer.

This feature is disabled by default and must be enable when building the consumer with `enableRetry(true)`. When enabled, if the consumer calls the `reconsumeLater` method, the message will be pushed to a `-RETRY` topic and redelivered to the consumer after the period defined when calling `reconsumeLater`.

The maximum number of time the message can be redelivered is defined by the `maxRedeliverCount` parameter of the DeadLetterPolicy of the consumer.

When this limit is reached, the message is sent to the dead letter topic.

In order to use the reconsumerLater API, we face a main issue:
While others pulsar methods need the MessageId to identify the
message, the reconsumeLater API needs the whole message.
Rebuilding the message based on the ConsumerMessage content
is complicated since we need to create a TopicMessageImpl
for consumers consuming multiple topics instead of a MessageImpl
and the TopicMessageImpl constructor has a package visiblity.
One solution is to expose a method that returns the base pulsar
message in one of the implementation of the ConsumerMessage.
This way, we reduce a bit the coupling between the Pulsar java API
and Pulsar4s as we don't expose the method directly in the
ConsumerMessage trait.

This PR aims to add the reconsumeLater API to the Scala implementation.